### PR TITLE
Work around haskell/cabal#5386 by setting the TMP env var

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,8 @@ clone_folder: "c:\\project"
 environment:
   global:
     STACK_ROOT: "c:\\sr"
+    # Workaround a gnarly bug https://github.com/haskell/cabal/issues/5386
+    TMP: "c:\\tmp"
 
 test_script:
 - echo "" | stack --no-terminal setup --resolver=nightly > nul


### PR DESCRIPTION
Works around haskell/cabal#5386

I'm going to recommend this as the fix for https://github.com/commercialhaskell/stack/issues/3944 via documentation updates.